### PR TITLE
Default redirects to last available year instead of current

### DIFF
--- a/middleware/redirection.js
+++ b/middleware/redirection.js
@@ -1,5 +1,7 @@
+import { years } from '../nuxt.config.js';
+
 export default function({ store, redirect }) {
   if (!location.href.match(/.*?\/(\d{4})(\/.*?)?$/gim)) {
-    window.location.href += new Date().getFullYear()
+    window.location.href += years[years.length - 1];
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,4 @@
-const years = [2013, 2014, 2015, 2016, 2018, 2019, 2020]
+export const years = [2013, 2014, 2015, 2016, 2018, 2019, 2020]
 
 const title = 'Indie Stunfest'
 const description = 'Welcome to the Stunfest Indie section !'


### PR DESCRIPTION
This should do the trick right?

I didn't push the static generated website on `gh-pages` because I used the online editor.